### PR TITLE
feature/collision-layers: Standardize collision layers and set Player collision mask

### DIFF
--- a/actors/player.tscn
+++ b/actors/player.tscn
@@ -8,7 +8,7 @@
 radius = 40.0
 
 [node name="Player" type="CharacterBody2D" unique_id=2145724321]
-collision_mask = 0
+collision_mask = 28
 script = ExtResource("1_mvpqy")
 
 [node name="RedShipSprite" type="Sprite2D" parent="." unique_id=399893877]

--- a/project.godot
+++ b/project.godot
@@ -82,6 +82,14 @@ p2_action={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_1="Player"
+2d_physics/layer_2="PlayerAttack"
+2d_physics/layer_3="Enemy"
+2d_physics/layer_4="EnemyAttack"
+2d_physics/layer_5="World"
+
 [physics]
 
 3d/physics_engine="Jolt Physics"

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -2,6 +2,8 @@
 
 [ext_resource type="PackedScene" uid="uid://buwwawpf4y78f" path="res://actors/player.tscn" id="1_uwrxv"]
 
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_uwrxv"]
+
 [node name="game" type="Node2D" unique_id=1924521991]
 
 [node name="Player1" parent="." unique_id=2145724321 instance=ExtResource("1_uwrxv")]
@@ -11,3 +13,13 @@ playerNumber = 1
 [node name="Player2" parent="." unique_id=969589887 instance=ExtResource("1_uwrxv")]
 position = Vector2(830, 273)
 playerNumber = 2
+
+[node name="WorldBorder" type="Node2D" parent="." unique_id=891419900]
+
+[node name="StaticBody2D" type="StaticBody2D" parent="WorldBorder" unique_id=783556734]
+collision_layer = 16
+collision_mask = 0
+physics_material_override = SubResource("PhysicsMaterial_uwrxv")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="WorldBorder/StaticBody2D" unique_id=493395772]
+polygon = PackedVector2Array(-4, -4, 1200, -4, 1200, 0, 0, 0, 0, 600, 1200, 600, 1200, -4, 1204, -4, 1204, 604, -4, 604)


### PR DESCRIPTION
- Standardized which collision layers should be used for which objects
  - See 7b3808be76cd4018a9d25710ae362756735d205b for instructions on how to check and update collision layer names.
- Added a world border that players cannot move through, containing them to the screen
- Updated the player's collision mask to only scan for enemies, enemy attacks, and world objects

We could potentially use layers for polarities if we want bodies to _entirely ignore_ objects of the other polarity (e.g. if we want a blue enemy projectile to phase through the blue player instead of despawning on contact), but this may reduce teamwork capability like blocking projectiles (like the big blue mega laser) on behalf of the other player.

Fixes #28, fixes #6 