### PR TITLE
Feature/player-health-damage

### DIFF
--- a/actors/meteroid.tscn
+++ b/actors/meteroid.tscn
@@ -4,9 +4,9 @@
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_dlr3y"]
 
-[node name="Meteoroid" type="Area2D" unique_id=559024023]
+[node name="Meteoroid" type="Area2D" unique_id=559024023 groups=["Enemy"]]
 z_index = 10
-collision_layer = 4
+collision_layer = 68
 collision_mask = 2
 script = ExtResource("1_dpgfl")
 min_speed = 20.0

--- a/actors/player.tscn
+++ b/actors/player.tscn
@@ -5,10 +5,13 @@
 [ext_resource type="Texture2D" uid="uid://dlyxecxxgt6m" path="res://assets/kenney_space-shooter-remastered/PNG/playerShip3_blue.png" id="3_1yqc4"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_1yqc4"]
-radius = 40.0
+radius = 24.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_esgq3"]
+radius = 36.0
 
 [node name="Player" type="CharacterBody2D" unique_id=2145724321]
-collision_mask = 28
+collision_mask = 16
 script = ExtResource("1_mvpqy")
 
 [node name="RedShipSprite" type="Sprite2D" parent="." unique_id=399893877]
@@ -20,3 +23,20 @@ texture = ExtResource("3_1yqc4")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=46676515]
 shape = SubResource("CircleShape2D_1yqc4")
+
+[node name="Hurtbox" type="Area2D" parent="." unique_id=255519528]
+collision_layer = 0
+collision_mask = 204
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox" unique_id=198870824]
+shape = SubResource("CircleShape2D_esgq3")
+
+[node name="HealthRichTextLabel" type="RichTextLabel" parent="." unique_id=1189969622]
+offset_left = -19.0
+offset_top = -81.0
+offset_right = 21.0
+offset_bottom = -41.0
+theme_override_font_sizes/normal_font_size = 29
+text = "3"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/actors/player.tscn
+++ b/actors/player.tscn
@@ -32,9 +32,9 @@ collision_mask = 204
 shape = SubResource("CircleShape2D_esgq3")
 
 [node name="HealthRichTextLabel" type="RichTextLabel" parent="." unique_id=1189969622]
-offset_left = -19.0
+offset_left = -435.0
 offset_top = -81.0
-offset_right = 21.0
+offset_right = 437.0
 offset_bottom = -41.0
 theme_override_font_sizes/normal_font_size = 29
 text = "3"

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,11 @@ Globals="*uid://bl033q4lk5qlc"
 
 window/size/viewport_width=1080
 window/size/viewport_height=1920
+window/stretch/mode="viewport"
+
+[global_group]
+
+Enemy=""
 
 [input]
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -18,17 +18,17 @@
 
 [node name="game" type="Node2D" unique_id=1924521991]
 
-[node name="Player1" parent="." unique_id=2145724321 node_paths=PackedStringArray("Laser") instance=ExtResource("1_uwrxv")]
-position = Vector2(253, 1784)
+[node name="Player1" parent="." unique_id=2145724321 node_paths=PackedStringArray("laser_manager") instance=ExtResource("1_uwrxv")]
+position = Vector2(302, 1778)
 collision_mask = 24
-playerNumber = 1
-Laser = NodePath("../LaserManager")
+player_number = 1
+laser_manager = NodePath("../LaserManager")
 
-[node name="Player2" parent="." unique_id=969589887 node_paths=PackedStringArray("Laser") instance=ExtResource("1_uwrxv")]
+[node name="Player2" parent="." unique_id=969589887 node_paths=PackedStringArray("laser_manager") instance=ExtResource("1_uwrxv")]
 position = Vector2(790, 1776)
 collision_mask = 24
-playerNumber = 2
-Laser = NodePath("../LaserManager")
+player_number = 2
+laser_manager = NodePath("../LaserManager")
 
 [node name="WorldBorder" type="Node2D" parent="." unique_id=891419900]
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -18,14 +18,22 @@
 
 [node name="game" type="Node2D" unique_id=1924521991]
 
+[node name="Player1Spawn" type="Marker2D" parent="." unique_id=1692881551]
+position = Vector2(270, 1650)
+gizmo_extents = 60.0
+
+[node name="Player2Spawn" type="Marker2D" parent="." unique_id=463786856]
+position = Vector2(810, 1650)
+gizmo_extents = 60.0
+
 [node name="Player1" parent="." unique_id=2145724321 node_paths=PackedStringArray("laser_manager") instance=ExtResource("1_uwrxv")]
-position = Vector2(302, 1778)
+position = Vector2(133, 1833)
 collision_mask = 24
 player_number = 1
 laser_manager = NodePath("../LaserManager")
 
 [node name="Player2" parent="." unique_id=969589887 node_paths=PackedStringArray("laser_manager") instance=ExtResource("1_uwrxv")]
-position = Vector2(790, 1776)
+position = Vector2(942, 1859)
 collision_mask = 24
 player_number = 2
 laser_manager = NodePath("../LaserManager")
@@ -37,10 +45,8 @@ collision_layer = 16
 collision_mask = 0
 physics_material_override = SubResource("PhysicsMaterial_uwrxv")
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="WorldBorder/StaticBody2D" unique_id=493395772]
-position = Vector2(-1.9404068, 1.2284279)
-scale = Vector2(0.88990057, 3.1791234)
-polygon = PackedVector2Array(-3.4381292, -3.3104334, 1200, -4, 1201.1907, -8.243978, 728.34106, -4.0235367, 414.1538, -2.915924, 0, 0, 0, 600, 1199, 603.72736, 1200, -4, 1204, -4, 1203.5731, 605.15344, -4, 604, -4, 209.40039)
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="WorldBorder/StaticBody2D" unique_id=635149500]
+polygon = PackedVector2Array(-20, 0, 1080, 0, 1080, 1920, 0, 1920, 0, 0, -20, 0, -20, 1940, 1100, 1940, 1100, -20, -20, -20)
 
 [node name="LaserManager" parent="." unique_id=1663080434 instance=ExtResource("3_lbhrr")]
 laser_scene = ExtResource("1_lnu2h")

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -1,3 +1,22 @@
 extends Node
 
 enum Polarity { RED, BLUE }
+
+var spawn_points: Array[Marker2D] = [null, null, null]
+
+
+func get_spawn_point(player_number: int) -> Vector2:
+	# Get cached spawn point if known
+	if spawn_points[player_number]:
+		print("Pulling cached spawn point for player %d" % player_number) #DEBUG
+		return spawn_points[player_number].get_global_position()
+	# Find spawn point if unknown
+	if spawn_points[player_number] == null:
+		var spawn_point: Marker2D = get_tree().root.find_child("Player"+str(player_number)+"Spawn", true, false)
+		if spawn_point:
+			print("Found and cached spawn point for player %d" % player_number) #DEBUG
+			spawn_points[player_number] = spawn_point
+			return spawn_point.get_global_position()
+	
+	push_warning("Failed to find spawn point Player%dSpawn" % player_number)
+	return Vector2(0,1920)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -10,11 +10,12 @@ extends CharacterBody2D
 ## The speed at which the player moves in pixels/second.
 @export var move_speed: float = 300
 
-@export var laser: Node2D
+@export var laser_manager: Node2D
 
 @export var fire_delay: float = 0.15
 
-
+@export var max_health: int = 3
+var health: int
 var polarity: Globals.Polarity = Globals.Polarity.RED
 var fire_timer: float = 0.0
 
@@ -22,11 +23,19 @@ var fire_timer: float = 0.0
 @onready var red_ship_sprite: Sprite2D = $RedShipSprite
 @onready var blue_ship_sprite: Sprite2D = $BlueShipSprite
 
+@onready var hurtbox: Area2D = $Hurtbox
+
+@onready var health_rich_text_label: RichTextLabel = $HealthRichTextLabel
+
 
 # ~~~~~ FUNCTIONALITY ~~~~~
 
+# ~ Godot Overrides ~
+
 func _ready() -> void:
+	health = max_health
 	update_ship_sprite()
+	update_health_ui()
 
 func _physics_process(delta: float) -> void:
 	var x_movement: float 
@@ -43,6 +52,13 @@ func _physics_process(delta: float) -> void:
 	velocity = direction * move_speed
 	
 	fire_timer += delta
+
+	for area: Area2D in hurtbox.get_overlapping_areas():
+		if area.is_in_group("Enemy") or area.is_in_group("EnemyAtk"):
+			if "polarity" in area:
+				if area.polarity != polarity:
+					reduce_health()
+					area.queue_free()
 
 	move_and_slide()
 
@@ -62,10 +78,11 @@ func _input(event: InputEvent) -> void:
 		get_viewport().set_input_as_handled()
 		fire()
 
+# ~ Helper Functions
 
 func fire():
-	if laser and fire_timer >= fire_delay:
-		laser.fire_laser(global_position, polarity)
+	if laser_manager and fire_timer >= fire_delay:
+		laser_manager.fire_laser(global_position, polarity)
 		fire_timer = 0.0
 
 func action():
@@ -85,3 +102,22 @@ func update_ship_sprite():
 	elif polarity == Globals.Polarity.BLUE:
 		red_ship_sprite.set_visible(false)
 		blue_ship_sprite.set_visible(true)
+
+
+func reduce_health(amount: int = 1):
+	health -= amount
+	if health <= 0:
+		die()
+	print("ow")
+	update_health_ui()
+
+func gain_health(amount: int = 1):
+	health = max(health + amount, max_health)
+	update_health_ui()
+
+func die():
+	print("Man I'm dead")
+
+func update_health_ui():
+	# We can change this function to call something on a UI element later.
+	health_rich_text_label.set_text(str(health))

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,6 +5,7 @@ extends CharacterBody2D
 # ~ Game Logic ~
 
 ## Indicates which player number the player is (1 or 2) or that the player is playing singleplayer (0).
+## NOTE: Player 0 is currently unsupported.
 @export var player_number: int = 0
 
 ## The speed at which the player moves in pixels/second.
@@ -18,6 +19,8 @@ extends CharacterBody2D
 var health: int
 var polarity: Globals.Polarity = Globals.Polarity.RED
 var fire_timer: float = 0.0
+
+var dead: bool = false
 
 # ~ Child Node References ~
 @onready var red_ship_sprite: Sprite2D = $RedShipSprite
@@ -36,49 +39,58 @@ func _ready() -> void:
 	health = max_health
 	update_ship_sprite()
 	update_health_ui()
+	set_global_position(Globals.get_spawn_point(player_number))
+	dead = false
 
 func _physics_process(delta: float) -> void:
-	var x_movement: float 
-	var y_movement: float 
-	if player_number == 1:
-		x_movement = Input.get_axis("p1_left", "p1_right")
-		y_movement = Input.get_axis("p1_up", "p1_down")
-	elif player_number == 2:
-		x_movement = Input.get_axis("p2_left", "p2_right")
-		y_movement = Input.get_axis("p2_up", "p2_down")
+	if not dead:
+		var x_movement: float 
+		var y_movement: float 
+		if player_number == 1:
+			x_movement = Input.get_axis("p1_left", "p1_right")
+			y_movement = Input.get_axis("p1_up", "p1_down")
+		elif player_number == 2:
+			x_movement = Input.get_axis("p2_left", "p2_right")
+			y_movement = Input.get_axis("p2_up", "p2_down")
 
-	var direction: Vector2 = Vector2(x_movement, y_movement).normalized()
+		var direction: Vector2 = Vector2(x_movement, y_movement).normalized()
 
-	velocity = direction * move_speed
-	
-	fire_timer += delta
+		velocity = direction * move_speed
+		
+		fire_timer += delta
 
-	for area: Area2D in hurtbox.get_overlapping_areas():
-		if area.is_in_group("Enemy") or area.is_in_group("EnemyAtk"):
-			if "polarity" in area:
-				if area.polarity != polarity:
-					reduce_health()
-					area.queue_free()
+		for area: Area2D in hurtbox.get_overlapping_areas():
+			if area.is_in_group("Enemy") or area.is_in_group("EnemyAtk"):
+				if "polarity" in area:
+					if area.polarity != polarity:
+						change_health(-1)
+						area.queue_free()
 
-	move_and_slide()
+		move_and_slide()
 
 func _input(event: InputEvent) -> void:
-	# Handle action
-	if player_number == 1 and event.is_action_pressed("p1_action"):
-		get_viewport().set_input_as_handled()
-		action()
-	if player_number == 2 and event.is_action_pressed("p2_action"):
-		get_viewport().set_input_as_handled()
-		action()
+	if not dead:
+		if player_number == 1 and event.is_action_pressed("p1_action"):
+			get_viewport().set_input_as_handled()
+			action()
+		if player_number == 2 and event.is_action_pressed("p2_action"):
+			get_viewport().set_input_as_handled()
+			action()
+		
+		if (player_number == 1 and event.is_action_pressed("p1_fire")):
+			get_viewport().set_input_as_handled()
+			fire()
+		if (player_number == 2 and event.is_action_pressed("p2_fire")):
+			get_viewport().set_input_as_handled()
+			fire()
 	
-	if (player_number == 1 and event.is_action_pressed("p1_fire")):
-		get_viewport().set_input_as_handled()
-		fire()
-	if (player_number == 2 and event.is_action_pressed("p2_fire")):
-		get_viewport().set_input_as_handled()
-		fire()
+	# Note: Action respawns player when dead. This is for ease of playtesting and should change when we implement an actual respawn mechanic.
+	else:
+		if (player_number == 1 and event.is_action_pressed("p1_action")) or (player_number == 2 and event.is_action_pressed("p2_action")):
+			_ready()
 
-# ~ Helper Functions
+
+# ~ Helper Functions ~
 
 func fire():
 	if laser_manager and fire_timer >= fire_delay:
@@ -103,20 +115,20 @@ func update_ship_sprite():
 		red_ship_sprite.set_visible(false)
 		blue_ship_sprite.set_visible(true)
 
-
-func reduce_health(amount: int = 1):
-	health -= amount
+func change_health(amount: int):
+	health += amount
+	if health > max_health:
+		health = max_health
+	update_health_ui()
 	if health <= 0:
 		die()
-	print("ow")
-	update_health_ui()
-
-func gain_health(amount: int = 1):
-	health = max(health + amount, max_health)
-	update_health_ui()
 
 func die():
-	print("Man I'm dead")
+	dead = true
+	blue_ship_sprite.set_visible(false)
+	red_ship_sprite.set_visible(false)
+	health_rich_text_label.set_text("Died! Press Action to respawn")
+	# Call _ready() to respawn the player
 
 func update_health_ui():
 	# We can change this function to call something on a UI element later.

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,82 +5,83 @@ extends CharacterBody2D
 # ~ Game Logic ~
 
 ## Indicates which player number the player is (1 or 2) or that the player is playing singleplayer (0).
-@export var playerNumber: int = 0
+@export var player_number: int = 0
 
 ## The speed at which the player moves in pixels/second.
-@export var moveSpeed: float = 300
+@export var move_speed: float = 300
 
-@export var Laser: Node2D
+@export var laser: Node2D
 
-@export var fireDelay: float = 0.15
+@export var fire_delay: float = 0.15
 
 
 var polarity: Globals.Polarity = Globals.Polarity.RED
-var fireTimer: float = 0.0
+var fire_timer: float = 0.0
 
 # ~ Child Node References ~
-@onready var redShipSprite: Sprite2D = $RedShipSprite
-@onready var blueShipSprite: Sprite2D = $BlueShipSprite
+@onready var red_ship_sprite: Sprite2D = $RedShipSprite
+@onready var blue_ship_sprite: Sprite2D = $BlueShipSprite
 
-func _ready() -> void:
-	UpdateShipSprite()
 
 # ~~~~~ FUNCTIONALITY ~~~~~
 
+func _ready() -> void:
+	update_ship_sprite()
+
 func _physics_process(delta: float) -> void:
-	var xMovement: float 
-	var yMovement: float 
-	if playerNumber == 1:
-		xMovement = Input.get_axis("p1_left", "p1_right")
-		yMovement = Input.get_axis("p1_up", "p1_down")
-	elif playerNumber == 2:
-		xMovement = Input.get_axis("p2_left", "p2_right")
-		yMovement = Input.get_axis("p2_up", "p2_down")
+	var x_movement: float 
+	var y_movement: float 
+	if player_number == 1:
+		x_movement = Input.get_axis("p1_left", "p1_right")
+		y_movement = Input.get_axis("p1_up", "p1_down")
+	elif player_number == 2:
+		x_movement = Input.get_axis("p2_left", "p2_right")
+		y_movement = Input.get_axis("p2_up", "p2_down")
 
-	var direction: Vector2 = Vector2(xMovement, yMovement).normalized()
+	var direction: Vector2 = Vector2(x_movement, y_movement).normalized()
 
-	velocity = direction * moveSpeed
+	velocity = direction * move_speed
 	
-	fireTimer += delta
+	fire_timer += delta
 
 	move_and_slide()
 
 func _input(event: InputEvent) -> void:
 	# Handle action
-	if playerNumber == 1 and event.is_action_pressed("p1_action"):
+	if player_number == 1 and event.is_action_pressed("p1_action"):
 		get_viewport().set_input_as_handled()
-		Action()
-	if playerNumber == 2 and event.is_action_pressed("p2_action"):
+		action()
+	if player_number == 2 and event.is_action_pressed("p2_action"):
 		get_viewport().set_input_as_handled()
-		Action()
+		action()
 	
-	if (playerNumber == 1 and event.is_action_pressed("p1_fire")):
+	if (player_number == 1 and event.is_action_pressed("p1_fire")):
 		get_viewport().set_input_as_handled()
-		Fire()
-	if (playerNumber == 2 and event.is_action_pressed("p2_fire")):
+		fire()
+	if (player_number == 2 and event.is_action_pressed("p2_fire")):
 		get_viewport().set_input_as_handled()
-		Fire()
+		fire()
 
 
-func Fire():
-	if Laser and fireTimer >= fireDelay:
-		Laser.fire_laser(global_position, polarity)
-		fireTimer = 0.0
+func fire():
+	if laser and fire_timer >= fire_delay:
+		laser.fire_laser(global_position, polarity)
+		fire_timer = 0.0
 
-func Action():
+func action():
 	# Only does a simple polarity switch for now. This is how it can function in singleplayer.
 	if polarity == Globals.Polarity.RED:
 		polarity = Globals.Polarity.BLUE
 	elif polarity == Globals.Polarity.BLUE:
 		polarity = Globals.Polarity.RED
 
-	UpdateShipSprite()
+	update_ship_sprite()
 
 ## Called after Polarity updates, and in _ready() to set to initial polarity.
-func UpdateShipSprite():
+func update_ship_sprite():
 	if polarity == Globals.Polarity.RED:
-		blueShipSprite.set_visible(false)
-		redShipSprite.set_visible(true)
+		blue_ship_sprite.set_visible(false)
+		red_ship_sprite.set_visible(true)
 	elif polarity == Globals.Polarity.BLUE:
-		redShipSprite.set_visible(false)
-		blueShipSprite.set_visible(true)
+		red_ship_sprite.set_visible(false)
+		blue_ship_sprite.set_visible(true)


### PR DESCRIPTION
Player now has an `Area2D` hurtbox which detects overlap with other `Area2D`s of opposite Polarity. The Player will take damage from these interactions, eventually dying when running out of health - from there, they may respawn with the Action key.

Meteorites are now in the Enemy group, and as such can now damage Players.

Fixes #5 