### PR TITLE
Resize window and some game objects

### DIFF
--- a/actors/meteroid.tscn
+++ b/actors/meteroid.tscn
@@ -9,8 +9,8 @@ z_index = 10
 collision_layer = 0
 collision_mask = 51
 script = ExtResource("1_dpgfl")
-min_speed = 100.0
-max_speed = 200.0
+min_speed = 80.0
+max_speed = 150.0
 hit_points = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=405041427]

--- a/actors/player.tscn
+++ b/actors/player.tscn
@@ -5,20 +5,22 @@
 [ext_resource type="Texture2D" uid="uid://dlyxecxxgt6m" path="res://assets/kenney_space-shooter-remastered/PNG/playerShip3_blue.png" id="3_1yqc4"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_1yqc4"]
-radius = 24.0
+radius = 22.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_esgq3"]
-radius = 36.0
+radius = 25.179358
 
 [node name="Player" type="CharacterBody2D" unique_id=2145724321 groups=["Player"]]
 collision_mask = 16
 script = ExtResource("1_mvpqy")
 
 [node name="RedShipSprite" type="Sprite2D" parent="." unique_id=399893877]
+scale = Vector2(0.7, 0.7)
 texture = ExtResource("1_5c43a")
 
 [node name="BlueShipSprite" type="Sprite2D" parent="." unique_id=284621941]
 visible = false
+scale = Vector2(0.7, 0.7)
 texture = ExtResource("3_1yqc4")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=46676515]

--- a/project.godot
+++ b/project.godot
@@ -20,10 +20,11 @@ Globals="*uid://bl033q4lk5qlc"
 
 [display]
 
-window/size/viewport_width=1080
-window/size/viewport_height=1920
+window/size/viewport_width=540
+window/size/viewport_height=960
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+window/handheld/orientation=1
 
 [global_group]
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -13,19 +13,19 @@
 [ext_resource type="Resource" uid="uid://25llfmmrvjle" path="res://resources/med_meteoroid_2.tres" id="12_1kice"]
 [ext_resource type="Resource" uid="uid://cxtmr8ebqgba3" path="res://resources/small_meteoroid_1.tres" id="13_5newe"]
 [ext_resource type="Resource" uid="uid://c6h2cn4wcs7tq" path="res://resources/small_meteoroid_2.tres" id="14_37s47"]
-[ext_resource type="PackedScene" uid="uid://cqj0osawxost" path="res://scenes/score_overlay.tscn" id="14_trtic"]
+[ext_resource type="PackedScene" uid="uid://c04mqx6ntmd8h" path="res://scenes/score_overlay.tscn" id="14_trtic"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_uwrxv"]
 
 [node name="game" type="Node2D" unique_id=1924521991]
 
 [node name="Player1Spawn" type="Marker2D" parent="." unique_id=1692881551]
-position = Vector2(270, 1650)
-gizmo_extents = 60.0
+position = Vector2(100, 860)
+gizmo_extents = 100.0
 
 [node name="Player2Spawn" type="Marker2D" parent="." unique_id=463786856]
-position = Vector2(810, 1650)
-gizmo_extents = 60.0
+position = Vector2(440, 860)
+gizmo_extents = 100.0
 
 [node name="Player1" parent="." unique_id=2145724321 node_paths=PackedStringArray("laser_manager") instance=ExtResource("1_uwrxv")]
 position = Vector2(133, 1833)
@@ -47,7 +47,7 @@ collision_mask = 0
 physics_material_override = SubResource("PhysicsMaterial_uwrxv")
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="WorldBorder/StaticBody2D" unique_id=635149500]
-polygon = PackedVector2Array(-20, 0, 1080, 0, 1080, 1920, 0, 1920, 0, 0, -20, 0, -20, 1940, 1100, 1940, 1100, -20, -20, -20)
+polygon = PackedVector2Array(-20, 0, 540, 0, 540, 960, 0, 960, 0, 0, -20, 0, -20, 980, 560, 980, 560, -20, -20, -20)
 
 [node name="LaserManager" parent="." unique_id=1663080434 instance=ExtResource("3_lbhrr")]
 laser_scene = ExtResource("1_lnu2h")
@@ -58,3 +58,6 @@ MEDIUM_METEOROIDS = Array[ExtResource("6_trtic")]([ExtResource("11_264po"), ExtR
 SMALL_METEOROIDS = Array[ExtResource("6_trtic")]([ExtResource("13_5newe"), ExtResource("14_37s47")])
 
 [node name="Score Overlay" parent="." unique_id=1629194483 instance=ExtResource("14_trtic")]
+offset = Vector2(50, 0)
+scale = Vector2(0.8, 0.8)
+transform = Transform2D(0.8, 0, 0, 0.8, 50, 0)


### PR DESCRIPTION
Resizes the game window to 540x960 (from 1080x1920).
- Makes the entire playing field viewable on most screens when viewport doesn't scale (i.e. web export)
- Prevents issue where upon starting game through Godot, the window is taller than the screen and difficult to move during testing
- Nice side effect: making the playing space smaller effectively "zooms" everything in and makes objects less far apart, mitigating an issue from playtesting where gameplay felt sluggish

This caused the player to appear too large and meteors to move too fast, so those were scaled down slightly.